### PR TITLE
Doku / Listen allg.: überflüssiges Element entfernt

### DIFF
--- a/documentation/liAllg.dita
+++ b/documentation/liAllg.dita
@@ -70,7 +70,7 @@
   &lt;item&gt;3ter Schlag. Ma&amp;#x0364;hnklee &lt;space dim="horizontal"/&gt; 325°&lt;/item&gt;&lt;lb/&gt;
   &lt;item&gt;4ter Schlag. Rocken &lt;space dim="horizontal"/&gt; 299°&lt;/item&gt;&lt;lb/&gt;
   &lt;item&gt;5ter Schlag. Wicken zu Gru&amp;#x0364;nfutter &lt;space dim="horizontal"/&gt; 525°&lt;/item&gt;&lt;lb/&gt;
-  &lt;item&gt;6ter Schlag. Rocken &lt;space dim="horizontal"/&gt; &lt;hi rendition="#u"&gt;500°&lt;/hi&gt;&lt;/item&gt;
+  &lt;item&gt;6ter Schlag. Rocken &lt;space dim="horizontal"/&gt; 500°&lt;/item&gt;
 &lt;/list&gt;</codeblock>
           <p><i>Quelle: 
             <xref href="http://www.deutschestextarchiv.de/thuenen_staat_1826/70" format="html"  scope="external">Thünen,


### PR DESCRIPTION
da die faksimilie die unterstreichung nicht enthält, sollte auch das markup-beispiel diese nicht enthalten. zumal ich den strich auch nicht als unterstreichung deuten würde.