### PR TITLE
Fix odd chaining dev

### DIFF
--- a/schema/basisformat.odd
+++ b/schema/basisformat.odd
@@ -65,7 +65,7 @@
         <body>
             <p>This is the TEI Customization for the DTA 'base format', used by the DFG Project
                 Deutsches Textarchiv (The German Text Archive).</p>
-        	<schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en" source="/path/to/file/basisformat_all.xml">
+        	<schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en" source="dist/basisformat_all.xml">
                 <!-- required modules -->
                 <moduleRef key="core" except="add del unclear"/>
                 <moduleRef key="header" except="handNote"/>

--- a/schema/basisformat_all.odd
+++ b/schema/basisformat_all.odd
@@ -62,7 +62,7 @@
         <body>
             <p>This is the TEI Customization for the DTA 'base format', used by the DFG Project
                 Deutsches Textarchiv (The German Text Archive).</p>
-            <schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en">
+            <schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en" source="tei:3.5.0">
                 <!-- required modules -->
                 <moduleRef key="core" include="abbr add addrLine address author bibl biblScope cb choice cit corr date del editor email expan foreign gap head hi item l lb lg list listBibl measure milestone name note orig p pb pubPlace publisher q quote ref reg resp respStmt sic sp speaker stage title unclear"/>
                 <moduleRef key="header" include="abstract availability biblFull classCode edition editionStmt editorialDecl encodingDesc extent fileDesc handNote idno langUsage language licence notesStmt profileDesc publicationStmt rendition seriesStmt sourceDesc tagsDecl teiHeader textClass titleStmt"/>

--- a/schema/basisformat_ms.odd
+++ b/schema/basisformat_ms.odd
@@ -66,7 +66,7 @@
         <body>
             <p>This is the TEI Customization for the DTA 'base format', used by the DFG Project
                 Deutsches Textarchiv (The German Text Archive).</p>
-        	<schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en" source="/path/to/file/basisformat_all.xml">
+        	<schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en" source="dist/basisformat_all.xml">
                 <!-- required modules -->
                 <moduleRef key="core" except="sp speaker stage"/>
                 <moduleRef key="header"/>


### PR DESCRIPTION
All ODD files idd not properly reference their code-source in `schemaSpec/@source`. This PR introduces a the following values:

* `tei:3.5.0` in `basisformat_all.odd`
* `dist/basisformat_all.xml` in both `basisformat.odd` and `basisformat_ms.odd`

Please consider this a hot-fix (for both master and dev branches).
While this PR makes the fix on the dev branch #84 provides the same fix for the master branch