### PR TITLE
125 place postscript, 106 mTop/mBottom in add 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@ Changelog
 # Version 1.3.0 vom XX.XX.2026
 
 * #55: Adresse
+* #125: place in postscript erlaubt 
+* #106: mTop/mBottom auch in add 
+* #129 unclear auch für Drucke
 
 # Version 1.2.0 vom 18.03.2025
 ## Dokumentation

--- a/documentation/brPostscriptum.dita
+++ b/documentation/brPostscriptum.dita
@@ -47,5 +47,33 @@
                 Ein Buch des Andenkens für ihre Freunde. Bd. 2. Berlin, 1834.
                 [Faksimile 442]</xref></i></p>
             </fig> </example>
+      <p>Wird ein handschriftlicher Brief transkribiert und steht das Postskriptum nicht im allgemeinen Textfluss kann
+      der Ort des Postskriptum mit Hilfe des Attributs <codeph>@place</codeph> notiert werden. Dabei sind folgende Werte möglich:</p>
+      <table>
+        <tgroup cols="2"><thead><row>
+              <entry><tt>@place</tt>-Wert</entry>
+              <entry>Bedeutung</entry>
+        </row></thead>
+          <tbody><row>
+              <entry><tt>mTop</tt></entry>
+              <entry>Postskriptum am oberen Rand</entry>
+          </row>
+            <row>
+              <entry><tt>mBottom</tt></entry>
+              <entry>Postscriptum am unteren Rand</entry>
+            </row>
+            <row>
+              <entry><tt>left</tt></entry>
+              <entry>Postskriptum am linken Rand</entry>
+            </row>
+            <row>
+              <entry><tt>right</tt></entry>
+              <entry>Postskriptum am rechten Rand</entry>
+            </row>
+          </tbody></tgroup>
+      </table>
+      <codeblock outputclass="language-xml">&lt;postscript place="right"&gt;
+        &lt;p&gt;[Postskriptum, das am rechten Rand notiert wurde]&lt;/p&gt;
+        &lt;/postscript&gt;</codeblock>
     </body>
 </topic>

--- a/documentation/dtabf.ditamap
+++ b/documentation/dtabf.ditamap
@@ -292,6 +292,7 @@
         <chapter href="editorEingriff.dita">
             <topicref href="eeAllg.dita"/>
             <topicref href="eeDruckfehler.dita"/>
+            <topicref href="msEditorCert.dita"/>
             <topicref href="abkuerzung.dita"/>
             <topicref href="normalisierung.dita"/>
             <topicref href="sachkommentar.dita"/>

--- a/documentation/msAddDel.dita
+++ b/documentation/msAddDel.dita
@@ -26,7 +26,7 @@
           <entry>Bedeutung</entry>
         </row></thead>
         <tbody><row>
-          <entry morerows="5"><codeph>&lt;add&gt;</codeph></entry>
+          <entry morerows="7"><codeph>&lt;add&gt;</codeph></entry>
           <entry><codeph>superlinear</codeph></entry>
           <entry>über der Zeile eingetragen</entry>
         </row>
@@ -49,7 +49,16 @@
         <row>
           <entry><codeph>right</codeph></entry>
           <entry>am rechten Rand eingetragen</entry>
-        </row></tbody></tgroup>
+        </row>
+          <row>
+            <entry><codeph>mTop</codeph></entry>
+            <entry>am oberen Rand eingetragen</entry>
+          </row>
+          <row>
+            <entry><codeph>mBottom</codeph></entry>
+            <entry>am unteren Rand eingetragen</entry>
+          </row>
+        </tbody></tgroup>
       </table>
       <p>Im Fall einer Tilgung wird die Art der Tilgung mit dem <codeph>@rendition</codeph>-Attribut
         des <codeph>&lt;del&gt;</codeph>-Elements wiedergegeben. Dabei sind folgende Werte für <codeph>@rendition</codeph>

--- a/documentation/msEditorCert.dita
+++ b/documentation/msEditorCert.dita
@@ -4,10 +4,10 @@
   <title>Unsichere Lesarten</title>
   <body>
     
-      <p>Ist die Leserlichkeit der Quelle eingeschränkt, sodass der Text rekonstruiert werden 
-        muss bzw. die Lesung des Editors nicht gesichert ist, kann dies durch die Elemente
-        <codeph>&lt;unclear&gt;</codeph> und <codeph>&lt;supplied&gt;</codeph> wiedergegeben werden.
-      </p>
+      <p>Ist die Leserlichkeit der (handschriftlichen oder gedruckten) Quelle eingeschränkt, sodass
+      der Text rekonstruiert werden muss bzw. die Lesung des Editors nicht gesichert ist, kann dies
+      durch die Elemente <codeph>&lt;unclear&gt;</codeph> und <codeph>&lt;supplied&gt;</codeph>
+      wiedergegeben werden. </p>
       <p>Dabei wird <codeph>&lt;unclear&gt;</codeph> verwendet, wenn in der
             Quelle vorhandenes Material nur undeutlich lesbar ist. Der Grund für
             die Verwendung des <codeph>&lt;unclear&gt;</codeph>-Elements wird

--- a/schema/basisformat.odd
+++ b/schema/basisformat.odd
@@ -67,7 +67,7 @@
                 Deutsches Textarchiv (The German Text Archive).</p>
         	<schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en" source="https://raw.githubusercontent.com/deutschestextarchiv/dtabf/refs/heads/dev/schema/dist/basisformat_all.xml">
                 <!-- required modules -->
-                <moduleRef key="core" except="add del unclear"/>
+                <moduleRef key="core" except="add del"/>
                 <moduleRef key="header" except="handNote"/>
                 <moduleRef key="tei"/>
                 <moduleRef key="textstructure"/>

--- a/schema/basisformat_all.odd
+++ b/schema/basisformat_all.odd
@@ -56,6 +56,7 @@
         </encodingDesc>
     	<revisionDesc>
     		<change>09.2024: Update to TEI P5 4.8.0</change>
+    	    <change when="2026-04-28">Refer to specific version of TEI Guidelines in vault (now: 4.11.0)</change>
     	</revisionDesc>
     </teiHeader>
     <text>
@@ -65,7 +66,7 @@
         <body>
             <p>This is the TEI Customization for the DTA 'base format', used by the DFG Project
                 Deutsches Textarchiv (The German Text Archive).</p>
-            <schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en">
+            <schemaSpec ident="basisformat" docLang="en" prefix="tei_" start="TEI" xml:lang="en" source="https://tei-c.org/Vault/P5/4.11.0/xml/tei/odd/p5subset.xml">
                 <!-- required modules -->
                 <moduleRef key="core" include="abbr add addrLine address author bibl biblScope cb choice cit corr date del editor email expan foreign gap head hi item l lb lg list listBibl measure milestone name note orig p pb pubPlace publisher q quote ref reg resp respStmt sic sp speaker stage title unclear"/>
             	<moduleRef key="header" include="abstract availability biblFull classCode correspDesc correspAction correspContext edition editionStmt editorialDecl encodingDesc extent fileDesc handNote idno langUsage language licence notesStmt profileDesc publicationStmt rendition seriesStmt sourceDesc tagsDecl teiHeader textClass titleStmt"/>

--- a/schema/basisformat_all.odd
+++ b/schema/basisformat_all.odd
@@ -1251,10 +1251,18 @@
                    <attList>
                        <attDef ident="facs" mode="delete"/>
                        <attDef ident="cert" mode="delete"/>
-                   		<attDef ident="n" mode="delete"/>
-                   		<attDef ident="place" mode="delete"/>
+                       <attDef ident="n" mode="delete"/>
                        <attDef ident="resp" mode="delete"/>
-                   		<attDef ident="sameAs" mode="delete"/>
+                   	<attDef ident="sameAs" mode="delete"/>
+                       <attDef ident="place" mode="change" usage="opt">
+                           <desc>describes where the postscript was placed, if not within the normal text flow</desc>
+                           <valList type="closed" mode="replace">
+                               <valItem ident="left"><desc>Linker Rand</desc></valItem>
+                               <valItem ident="right"><desc>Rechter Rand</desc></valItem>
+                               <valItem ident="mTop"><desc>Manuskripte: am oberen Rand</desc></valItem>
+                               <valItem ident="mBottom"><desc>Manuskripte: am unteren Rand</desc></valItem>
+                           </valList>
+                       </attDef>
                    </attList>
                </elementSpec>
                <elementSpec ident="pubPlace" module="core" mode="change">

--- a/schema/basisformat_all.odd
+++ b/schema/basisformat_all.odd
@@ -333,6 +333,8 @@
                                <valItem ident="sublinear"><desc>Manuskripte: Einfügung unter der Zeile.</desc></valItem>
                                <valItem ident="left"><desc>Manuskripte: Einfügung am linken Rand.</desc></valItem>
                                <valItem ident="right"><desc>Manuskripte: Einfügung am rechten Rand.</desc></valItem>
+                               <valItem ident="mTop"><desc>Manuskripte: am oberen Rand</desc></valItem>
+                               <valItem ident="mBottom"><desc>Manuskripte: am unteren Rand</desc></valItem>
                            </valList>
                        </attDef>
                        <attDef ident="sameAs" mode="delete"/>


### PR DESCRIPTION
Details siehe Ticket #125

### #125 place in postscript

Umgesetzt. Zwei offene Fragen: 

* Ich habe die Doku für postscript/@place in brPostscript.xml ergänzt - oder macht woanders mehr Sinn?
* Die Positionierung soll nur angegeben werden, wenn sie nicht im normalen Textfluss steht
* Das Schema ist in all entsprechend für postscript geändert worden, soll es für DTABfprint noch explizit wieder ausgeschlossen werden? M.E. kommt ja eine Platzierung rechts, links, oben, unten im Druck nicht vor.

### #106 mTop/mBottom in place 

* Anpassungen für #106 in diesen Branch gepusht.

### #129 unclear auch für Drucke 

* Umgesetzt in diesem Branch